### PR TITLE
feat: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Server-side environment variables
+HELIUS_API_KEY=""
+BIRDEYE_API_KEY=""
+BSCSCAN_API_KEY=""
+JUPITER_LEND_API_KEY=""
+
+# Client-side environment variables
+NEXT_PUBLIC_PRIVY_APP_ID=""

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,12 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.sentry-build-plugin
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
Adding `.env.example` to help developers see the required environment variables.

## Problem
Closes #21

## Solution
Extracted the expected variables from `env.mjs` into `.env.example`, and updated `.gitignore` to stop ignoring `.env.example`.

## Checklist
- [x] Adds .env.example